### PR TITLE
CMake projects and Constant Integration

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,76 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: macos-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: macos-latest
+            c_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest --build-config ${{ matrix.build_type }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/cmake-build-*/
+/.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(agmv LANGUAGES C VERSION 1.0.0)
+
+add_subdirectory(extern/agidl)
+
+add_library(agmv STATIC
+        src/agmv_decode.c
+        src/agmv_encode.c
+        src/agmv_playback.c
+        src/agmv_utils.c
+)
+target_include_directories(agmv PUBLIC include)
+target_link_libraries(agmv PRIVATE agidl)
+
+add_subdirectory(tools/agmvcli)

--- a/extern/agidl/CMakeLists.txt
+++ b/extern/agidl/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(agidl LANGUAGES C VERSION 1.0.0)
+
+file(GLOB sources CONFIGURE_DEPENDS src/agidl_*.c)
+
+add_library(agidl STATIC ${sources})
+target_include_directories(agidl PUBLIC include)
+if(UNIX AND NOT APPLE) # Linux
+    target_link_libraries(agidl PUBLIC m)
+endif()

--- a/extern/agidl/src/agidl_img_gxt.c
+++ b/extern/agidl/src/agidl_img_gxt.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <math.h>
 #include "agidl_img_gxt.h"
+
+#include <agidl_mmu_utils.h>
+
 #include "agidl_cc_core.h"
 #include "agidl_math_utils.h"
 #include "agidl_img_error.h"

--- a/extern/agidl/src/agidl_img_pcx.c
+++ b/extern/agidl/src/agidl_img_pcx.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "agidl_img_pcx.h"
+
+#include <agidl_mmu_utils.h>
+
 #include "agidl_cc_core.h"
 #include "agidl_img_compression.h"
 #include "agidl_img_error.h"

--- a/extern/agidl/src/agidl_img_pvr.c
+++ b/extern/agidl/src/agidl_img_pvr.c
@@ -2,6 +2,9 @@
 #include <string.h>
 #include <math.h>
 #include "agidl_img_pvr.h"
+
+#include <agidl_mmu_utils.h>
+
 #include "agidl_cc_core.h"
 #include "agidl_math_utils.h"
 #include "agidl_img_error.h"

--- a/extern/agidl/src/agidl_img_search.c
+++ b/extern/agidl/src/agidl_img_search.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "agidl_img_search.h"
+
+#include <agidl_imgp_impl.h>
+
 #include "agidl_img_error.h"
 #include "agidl_file_utils.h"
 #include "agidl_img_converter.h"

--- a/extern/agidl/src/agidl_img_tga.c
+++ b/extern/agidl/src/agidl_img_tga.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "agidl_img_tga.h"
+
+#include <agidl_mmu_utils.h>
+
 #include "agidl_cc_core.h"
 #include "agidl_img_compression.h"
 #include "agidl_img_error.h"

--- a/extern/agidl/src/agidl_img_tim.c
+++ b/extern/agidl/src/agidl_img_tim.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include "agidl_cc_core.h"
 #include "agidl_img_tim.h"
+
+#include <agidl_mmu_utils.h>
+
 #include "agidl_img_error.h"
 #include "agidl_file_utils.h"
 #include "agidl_imgp_scale.h"

--- a/extern/agidl/src/agidl_img_types.c
+++ b/extern/agidl/src/agidl_img_types.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "agidl_img_types.h"
+
+#include <agidl_math_utils.h>
+
 #include "agidl_imgp_scale.h"
 #include "agidl_cc_core.h"
 

--- a/extern/agidl/src/agidl_imgp_font.c
+++ b/extern/agidl/src/agidl_imgp_font.c
@@ -197,6 +197,8 @@ int AGIDL_GetFontLen(AGIDL_FONT* font){
 	return font->num_of_letters;
 }
 
+int AGIDL_InsideClipBounds(u32 x, u32 y, u32 width, u32 height);
+
 void AGIDL_BlitFont(AGIDL_FONT* font, char c, void* data, u32 x, u32 y, u32 width, u32 height, AGIDL_CLR_FMT fmt){
 	if(AGIDL_GetBitCount(fmt) != 16){
 		COLOR* clrdata = (COLOR*)data;

--- a/extern/agidl/src/agidl_imgp_impl.c
+++ b/extern/agidl/src/agidl_imgp_impl.c
@@ -14,6 +14,8 @@
 
 #include "agidl_imgp_impl.h"
 
+#include <stdlib.h>
+
 void AGIDL_GrayscaleBMP(AGIDL_BMP* bmp){
 	if(AGIDL_GetBitCount(AGIDL_BMPGetClrFmt(bmp)) == 16){
 		AGIDL_GrayscaleImgData(bmp->pixels.pix16,AGIDL_BMPGetWidth(bmp),AGIDL_BMPGetHeight(bmp),

--- a/extern/agidl/src/agidl_imgp_scale.c
+++ b/extern/agidl/src/agidl_imgp_scale.c
@@ -14,6 +14,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "agidl_imgp_scale.h"
+
+#include <tgmath.h>
+
 #include "agidl_cc_mixer.h"
 #include "agidl_math_utils.h"
 

--- a/src/agmv_utils.c
+++ b/src/agmv_utils.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include "agmv_utils.h"
 
+#include <agmv_decode.h>
+
 /*-------FILE READING UTILITY FUNCTIONS------*/
 
 Bool AGMV_EOF(FILE* file){
@@ -1425,6 +1427,8 @@ int AGMV_ResetFrameRate(const char* filename, u32 frames_per_second){
 
 	return NO_ERR;
 }
+
+void to_80bitfloat(u32 num, u8 bytes[10]);
 
 void AGMV_ExportAudioType(FILE* audio, AGMV* agmv, AGMV_AUDIO_TYPE audio_type){
 	int i;

--- a/tools/agmvcli/CMakeLists.txt
+++ b/tools/agmvcli/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(agmvcli LANGUAGES C VERSION 1.0.0)
+
+add_executable(agmvcli agmvcli.c)
+target_link_libraries(agmvcli PRIVATE agmv)


### PR DESCRIPTION
# CMake projects for `libagidl`, `libagmv`, and `agmvcli`

The CMake projects can be configured and built with:

```shell
cmake -B build/ -DCMAKE_BUILD_TYPE=Release .
cmake --build build/ --config Release
```

For now I have only added CMake projects for `agmvcli` and its dependencies - we should expand this to `agmvp` if possible.

This also means `ctest` unit tests can be written (also not done in this PR).

# GitHub action for building `libagidl`, `libagmv`, and `agmvcli` against `ubuntu-latest`, `windows-latest`, and `macos-latest`

This provides some constant integration to keep this project building. The CI does run `ctest`, but right now there's no tests (we should add those).

I had to apply some fixes for macOS, and there's a lot of warnings that need solving (I'm keen to do this because at the moment this software segmentation faults for myself...).